### PR TITLE
Pathfind

### DIFF
--- a/Maze.cpp
+++ b/Maze.cpp
@@ -214,14 +214,17 @@ unsigned Maze::calculateMovementCost(Direction currentDirection, Direction nextD
 		// Goiing straight has no additional cost.
 		return cost;
 	case 1:
+	case 7:
 		// Turning 45deg costs moving a quarter cell.
 		// This is an approximation. 
 		return cost + MOVEMENT_COST / 4;
 	case 2:
+	case 6:
 		// Turning 90deg costs moving a half cell.
 		// This is an approximation. 
 		return cost + MOVEMENT_COST / 2;
 	case 3:
+	case 5:
 		// Turning 135deg costs moving two cells.
 		// We probably never want to do this it is a very difficult turn to make.
 		// This is an approximation. 

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -57,7 +57,8 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end, Direction facing )
 	resetNodePathData();
 	
 	// The start node is 0 distance away.
-	startNode->setScores(0, heuristic(start, end));
+	startNode->gScore = 0;
+	startNode->fScore = heuristic(start, end);
 	startNode->direction = facing;
 
 	// While there are node remaining to be evaluated.
@@ -115,7 +116,8 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end, Direction facing )
 			// This path is the best so far.
 			adjacentNode->previous = *currentNodeItr;
 			auto heuristicScore = heuristic((*currentNodeItr)->pos, end);
-			(*currentNodeItr)->setScores(tentativeScore, adjacentNode->gScore + heuristicScore);
+			(*currentNodeItr)->gScore = tentativeScore;
+			(*currentNodeItr)->fScore = adjacentNode->gScore + heuristicScore;
 		}
 	}
 

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -101,7 +101,7 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 		if ( *currentNodeItr == getNode( end ) )
 		{
 			// We are done. Construct the path.
-			return Path(); // TODO construct path.
+			return constructPath(*currentNodeItr);
 		}
 		
 		// Set the current node as evaluated.
@@ -211,4 +211,23 @@ unsigned Maze::heuristic(NodeCoordinate start, NodeCoordinate end)
 #else
 	return abs(start.x - end.x) + abs(start.y - end.y);
 #endif // MAZE_DIAGONALS
+}
+
+Path Maze::constructPath(Node * end)
+{
+	Path path;
+
+	const Node * nodeA = end->previous;
+	const Node * nodeB = end;
+
+	// while there is more to the path to traverse
+	while (nodeA)
+	{
+		//drawLine( nodeA->pos, nodeB->pos );
+		path.push(DirectionVector(nodeA->direction, 1));
+		nodeB = nodeA;
+		nodeA = nodeA->previous;
+	}
+
+	return path;
 }

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -12,7 +12,7 @@ const CellCoordinate  Maze::CELL_FINISH = CellCoordinate(Maze::CELL_COLS / 2, Ma
 void Maze::reset() {
 	for (int y = 0; y < NODE_ROWS; y++)
 		for (int x = 0; x < NODE_COLS; x++)
-			maze[y][x] = Node();
+			maze[y][x] = Node(NodeCoordinate(x,y));
 }
 
 

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -1,6 +1,5 @@
 #include "Maze.h"
 #include <stdexcept>
-#include <unordered_set>
 #include <set>
 #include <cstdlib> //abs
 
@@ -81,11 +80,6 @@ void Maze::setWall(CellCoordinate pos, Direction dir, bool wall) {
 
 Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 {
-	// Nodes that have already been evaluated.
-	// Initialize the size to half of the total nodes as a best guess.
-	// TODO: Find the average max size to use as initial size.
-	unordered_set<Node *> closedNodes(NODE_ROWS * NODE_COLS * 0.5);
-
 	// The nodes that still need to be evaluated.
 	// Initially insert the start node.
 	set<Node *> openNodes;
@@ -110,9 +104,9 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 			return Path(); // TODO construct path.
 		}
 		
-		// Move the current node into the closed nodes.
+		// Set the current node as evaluated.
 		openNodes.erase(currentNodeItr);
-		closedNodes.insert(*currentNodeItr);
+		(*currentNodeItr)->evaluated = true;
 
 		// For each node adjacent to the current node.
 		for (
@@ -127,8 +121,8 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 		{
 			Node * adjacentNode = getAdjacentNode(*currentNodeItr, direction);
 
-			// If the adjacent node has already been evaluated.
-			if (closedNodes.find(adjacentNode) != closedNodes.end())
+			// If the adjacent node has already been evaluated or does not exist.
+			if (adjacentNode->evaluated || !adjacentNode->exists)
 			{
 				// Ignore the adjacent node.
 				continue;
@@ -142,6 +136,7 @@ Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 				// Discover a new node.
 				openNodes.insert(adjacentNode);
 			}
+			// If the previous score given to the adjacent node is better.
 			else if (tentativeScore >= adjacentNode->gScore)
 			{
 				// This is not a better path.

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -1,5 +1,10 @@
 #include "Maze.h"
 #include <stdexcept>
+#include <unordered_set>
+#include <set>
+#include <cstdlib> //abs
+
+using namespace std;
 
 const CellCoordinate Maze::CELL_START = CellCoordinate(0,0);
 const CellCoordinate  Maze::CELL_FINISH = CellCoordinate(Maze::CELL_COLS / 2, (Maze::CELL_ROWS / 2);
@@ -76,9 +81,139 @@ void Maze::setWall(CellCoordinate pos, Direction dir, bool wall) {
 
 Path Maze::findPath(CellCoordinate start, CellCoordinate end)
 {
+	// Nodes that have already been evaluated.
+	// Initialize the size to half of the total nodes as a best guess.
+	// TODO: Find the average max size to use as initial size.
+	unordered_set<Node *> closedNodes(NODE_ROWS * NODE_COLS * 0.5);
 
+	// The nodes that still need to be evaluated.
+	// Initially insert the start node.
+	set<Node *> openNodes;
+	openNodes.insert(getNode(start));
+	
+	// Reset any metadata from previous pathfinding.
+	resetNodePathData();
+	
+	// The start node is 0 distance away.
+	getNode(start)->setScores(0, heuristic(start, end));
 
+	// While there are node remaining to be evaluated.
+	while (!openNodes.empty())
+	{
+		// Get the open node with lowest score.
+		auto currentNodeItr = openNodes.begin();
 
+		// If the current node is the finish node.
+		if ( *currentNodeItr == getNode( end ) )
+		{
+			// We are done. Construct the path.
+			return Path(); // TODO construct path.
+		}
+		
+		// Move the current node into the closed nodes.
+		openNodes.erase(currentNodeItr);
+		closedNodes.insert(*currentNodeItr);
 
-	return Path();
+		// For each node adjacent to the current node.
+		for (
+			Direction direction = Direction::N;
+			direction != Direction::NONE;
+#ifdef MAZE_DIAGONALS
+			direction = static_cast<Direction>(direction + 1)
+#else
+			direction = static_cast<Direction>(direction + 2)
+#endif // MAZE_DIAGONALS
+			)
+		{
+			Node * adjacentNode = getAdjacentNode(*currentNodeItr, direction);
+
+			// If the adjacent node has already been evaluated.
+			if (closedNodes.find(adjacentNode) != closedNodes.end())
+			{
+				// Ignore the adjacent node.
+				continue;
+			}
+
+			auto tentativeScore = (*currentNodeItr)->gScore + calculateMovementCost( direction );
+
+			// If adjacent node not in openNodes.
+			if (openNodes.find(adjacentNode) == openNodes.end() )
+			{
+				// Discover a new node.
+				openNodes.insert(adjacentNode);
+			}
+			else if (tentativeScore >= adjacentNode->gScore)
+			{
+				// This is not a better path.
+				continue;
+			}
+
+			// This path is the best so far.
+			adjacentNode->previous = *currentNodeItr;
+			auto heuristicScore = heuristic((*currentNodeItr)->pos, end);
+			(*currentNodeItr)->setScores(tentativeScore, adjacentNode->gScore + heuristicScore);
+		}
+	}
+
+	throw runtime_error("No path found");
+}
+
+Node * Maze::getNode(NodeCoordinate pos)
+{
+	return &maze[pos.y][pos.x];
+}
+
+Node * Maze::getAdjacentNode(Node * node, Direction direction)
+{
+	return getNode(node->pos + direction);
+}
+
+void Maze::resetNodePathData()
+{
+	for (size_t y = 0; y < CELL_ROWS; y++)
+	{
+		for (size_t x = 0; x < CELL_COLS; x++)
+		{
+			Node * node = getNode(NodeCoordinate(x, y));
+
+			if (*node)
+			{
+				node->resetPathData();
+			}
+		}
+	}
+}
+
+unsigned Maze::calculateMovementCost(Direction direction)
+{
+	switch (direction)
+	{
+	case N:
+	case E:
+	case S:
+	case W:
+		return 100;
+	case NE:
+	case SE:
+	case SW:
+	case NW:
+		return 141;
+	default:
+		throw std::invalid_argument("Direction cannot be: NONE");
+	}
+}
+
+unsigned Maze::heuristic(NodeCoordinate start, NodeCoordinate end)
+{
+#ifdef MAZE_DIAGONALS
+	int deltaX = abs(start.x - end.x);
+	int deltaY = abs(start.y - end.y);
+
+	if (deltaX>deltaY)
+		return (deltaX - deltaY) * MOVEMENT_COST + deltaY * MOVEMENT_COST_DIAGONAL;
+	else
+		return (deltaY - deltaX) * MOVEMENT_COST + deltaX * MOVEMENT_COST_DIAGONAL;
+#else
+	return abs(start.x - end.x) + abs(start.y - end.y);
+#endif // MAZE_DIAGONALS
 }

--- a/Maze.h
+++ b/Maze.h
@@ -31,13 +31,16 @@ class Maze {
 
     void reset();
 
-	Path findPath(CellCoordinate start = CELL_START, CellCoordinate end = CELL_FINISH);
+	// Returns a path from the `start` coordinate to the `end` coordinate
+	// `facing` is the direction the mouse is currently facing. If given
+	// paths that start in the same direction will be weighted more heavily.
+	Path findPath(CellCoordinate start, CellCoordinate end, Direction facing = NONE);
 
   private:
 	  Node* getNode(NodeCoordinate pos);
 	  Node* getAdjacentNode(Node* node, Direction direction);
 	  void resetNodePathData();
-	  unsigned calculateMovementCost(Direction direction);
+	  unsigned calculateMovementCost(Direction currentDirection, Direction nextDirection);
 	  unsigned heuristic(NodeCoordinate start, NodeCoordinate end);
 	  Path constructPath( Node* end );
 

--- a/Maze.h
+++ b/Maze.h
@@ -39,6 +39,7 @@ class Maze {
 	  void resetNodePathData();
 	  unsigned calculateMovementCost(Direction direction);
 	  unsigned heuristic(NodeCoordinate start, NodeCoordinate end);
+	  Path constructPath( Node* end );
 
     Node maze[NODE_ROWS][NODE_COLS];
 };

--- a/Maze.h
+++ b/Maze.h
@@ -6,6 +6,8 @@
 #include "Node.h"
 #include "Path.h"
 
+//#define MAZE_DIAGONALS
+
 class Maze {
   public:
     static const int CELL_ROWS = 16;
@@ -15,6 +17,9 @@ class Maze {
 
 	static const CellCoordinate CELL_START;
 	static const CellCoordinate CELL_FINISH;
+
+	static const unsigned MOVEMENT_COST = 100;
+	static const unsigned MOVEMENT_COST_DIAGONAL = 141;
 
 	Maze();
 
@@ -29,6 +34,12 @@ class Maze {
 	Path findPath(CellCoordinate start = CELL_START, CellCoordinate end = CELL_FINISH);
 
   private:
+	  Node* getNode(NodeCoordinate pos);
+	  Node* getAdjacentNode(Node* node, Direction direction);
+	  void resetNodePathData();
+	  unsigned calculateMovementCost(Direction direction);
+	  unsigned heuristic(NodeCoordinate start, NodeCoordinate end);
+
     Node maze[NODE_ROWS][NODE_COLS];
 };
 

--- a/Node.cpp
+++ b/Node.cpp
@@ -25,9 +25,3 @@ void Node::resetPathData()
 	evaluated = false;
 	direction = NONE;
 }
-
-void Node::setScores(unsigned gScore, unsigned fScore)
-{
-	this->gScore = gScore;
-	this->fScore = fScore;
-}

--- a/Node.cpp
+++ b/Node.cpp
@@ -22,6 +22,7 @@ void Node::resetPathData()
 	gScore = numeric_limits<unsigned>::max();
 	fScore = numeric_limits<unsigned>::max();
 	previous = nullptr;
+	evaluated = false;
 }
 
 void Node::setScores(unsigned gScore, unsigned fScore)

--- a/Node.cpp
+++ b/Node.cpp
@@ -23,6 +23,7 @@ void Node::resetPathData()
 	fScore = numeric_limits<unsigned>::max();
 	previous = nullptr;
 	evaluated = false;
+	direction = NONE;
 }
 
 void Node::setScores(unsigned gScore, unsigned fScore)

--- a/Node.cpp
+++ b/Node.cpp
@@ -1,9 +1,31 @@
 #include "Node.h"
+#include <limits>
 
-Node::Node(void) {
-    exists = true;
-}
+using namespace std;
+
+Node::Node(void):
+	pos(NodeCoordinate(0,0)),
+	exists(false)
+{}
+
+Node::Node(NodeCoordinate pos):
+	pos(pos),
+	exists(true)
+{}
 
 Node::operator bool() const {
     return exists;
+}
+
+void Node::resetPathData()
+{
+	gScore = numeric_limits<unsigned>::max();
+	fScore = numeric_limits<unsigned>::max();
+	previous = nullptr;
+}
+
+void Node::setScores(unsigned gScore, unsigned fScore)
+{
+	this->gScore = gScore;
+	this->fScore = fScore;
 }

--- a/Node.h
+++ b/Node.h
@@ -15,5 +15,7 @@ class Node {
 	unsigned gScore;
 	unsigned fScore;
 	Node * previous;
+	Direction direction;
 	bool evaluated;
+
 };

--- a/Node.h
+++ b/Node.h
@@ -6,7 +6,6 @@ class Node {
 	Node(NodeCoordinate pos);
     explicit operator bool() const;
 	void resetPathData();
-	void setScores(unsigned gScore, unsigned fScore);
 
 	NodeCoordinate pos;
     bool exists;

--- a/Node.h
+++ b/Node.h
@@ -1,6 +1,18 @@
+#include "Coordinate.h"
+
 class Node {
   public:
     Node(void);
+	Node(NodeCoordinate pos);
     explicit operator bool() const;
+	void resetPathData();
+	void setScores(unsigned gScore, unsigned fScore);
+
+	NodeCoordinate pos;
     bool exists;
+
+	// These are used for pathfinding
+	unsigned gScore;
+	unsigned fScore;
+	Node * previous;
 };

--- a/Node.h
+++ b/Node.h
@@ -15,4 +15,5 @@ class Node {
 	unsigned gScore;
 	unsigned fScore;
 	Node * previous;
+	bool evaluated;
 };


### PR DESCRIPTION
closes #10 

## Adds to Maze
public:
- Path Maze::findPath(CellCoordinate start, CellCoordinate end, Direction facing = NONE);
	// Returns a path from the `start` coordinate to the `end` coordinate
	// `facing` is the direction the mouse is currently facing. If given
	// paths that start in the same direction will be weighted more heavily.

private:
- Node* Maze::getNode(NodeCoordinate pos);
- Node* Maze::getAdjacentNode(Node* node, Direction direction);
- void Maze::resetNodePathData();
- unsigned Maze::calculateMovementCost(Direction currentDirection, Direction nextDirection);
- unsigned Maze::heuristic(NodeCoordinate start, NodeCoordinate end);
- Path Maze::constructPath( Node* end );

Some additions were made to Nodes to hold metadata for  pathfinding