### PR TITLE
Fix compiling on Teensy

### DIFF
--- a/Micromouse/Mouse.cpp
+++ b/Micromouse/Mouse.cpp
@@ -71,10 +71,12 @@ void Mouse::runMaze() {
 #endif
 }
 
+#if !defined(__MK66FX1M0__) && !defined(__MK20DX256__)
 void Mouse::stopMaze() {
     std::lock_guard<std::mutex> lock(mtx);
     running = false;
 }
+#endif
 
 void Mouse::setMappingSpeed(unsigned mmps) {
     mappingSpeed = mmps;

--- a/Micromouse/Mouse.h
+++ b/Micromouse/Mouse.h
@@ -20,13 +20,14 @@ class Mouse {
 #if !defined(__MK66FX1M0__) && !defined(__MK20DX256__)
     friend class Simulator;
     friend class MouseDrawable;
+
+    void stopMaze();
 #endif
 
     Mouse();
 
     void mapMaze();
     void runMaze();
-    void stopMaze();
 
     // In millimeter per second.
     void setMappingSpeed(unsigned mmps);


### PR DESCRIPTION
disabled `stopMaze` on Teensy compiles because there is no need unless you have another thread to call it from.

Fixes compiling on Teensy due to lock guards in `stopMaze`
