### PR TITLE
Color Gradient

### DIFF
--- a/Micromouse/Maze.cpp
+++ b/Micromouse/Maze.cpp
@@ -7,13 +7,13 @@
 #include <vector>
 
 #if !defined(__MK66FX1M0__) && !defined(__MK20DX256__)
-#include "../Simulation/simulate.h"
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
+#include "../Simulation/simulate.h"
 #endif
 
 //#define MAZE_DIAGONALS

--- a/Micromouse/Maze.cpp
+++ b/Micromouse/Maze.cpp
@@ -7,13 +7,13 @@
 #include <vector>
 
 #if !defined(__MK66FX1M0__) && !defined(__MK20DX256__)
+#include "../Simulation/simulate.h"
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
-#include "../Simulation/simulate.h"
 #endif
 
 //#define MAZE_DIAGONALS
@@ -233,6 +233,7 @@ void Maze::findPath(NodeCoordinate start, const NodeCoordinateList &ends,
         sort(openNodes.begin(), openNodes.end(), Maze::scoreComparator);
         auto currentNodeItr = openNodes.begin();
         auto currentNode = *currentNodeItr;
+        path.cost = currentNode->fScore;
 
         // If the current node is any of the end nodes.
         for (auto &i : ends) {
@@ -421,6 +422,7 @@ unsigned Maze::heuristic(NodeCoordinate start, NodeCoordinate end) {
 
 void Maze::constructPath(Node *start) {
     path.clear();
+    path.cost = start->gScore;
 
     const Node *i;
     // while there is more to the path to traverse

--- a/Micromouse/Path.h
+++ b/Micromouse/Path.h
@@ -6,7 +6,7 @@
 
 class Path {
   public:
-    Path() : start(0, 0) {
+    Path() : start(0, 0), cost(0) {
     }
     std::vector<DirectionVector>::const_reverse_iterator begin() const;
     std::vector<DirectionVector>::const_reverse_iterator end() const;
@@ -14,6 +14,7 @@ class Path {
     void push_back(DirectionVector vec);
     void clear();
     NodeCoordinate start;
+    unsigned cost;
 
   private:
     std::vector<DirectionVector> directions;

--- a/Simulation/simulate.cpp
+++ b/Simulation/simulate.cpp
@@ -235,7 +235,7 @@ class Simulator : public sf::RenderWindow {
                            sf::Style::Default, sf::ContextSettings(0, 0, 8))
         , mouse(mouse) {
         try {
-            mouse.virtualMaze = Maze::fromFile("1.maze");
+            mouse.virtualMaze = Maze::fromFile("2.maze");
         } catch (const std::exception &e) {
             std::cout << e.what();
         }

--- a/Simulation/simulate.cpp
+++ b/Simulation/simulate.cpp
@@ -20,6 +20,47 @@ sf::Vector2f nodeVector(NodeCoordinate c) {
     return sf::Vector2f(.5 + c.x, Maze::NODE_ROWS - c.y - .5) * NODE_SIZE;
 }
 
+void HSVtoRGB(float &fR, float &fG, float &fB, float fH, float fS, float fV) {
+    float fC = fV * fS; // Chroma
+    float fHPrime = fmod(fH / 60.0, 6);
+    float fX = fC * (1 - fabs(fmod(fHPrime, 2) - 1));
+    float fM = fV - fC;
+
+    if (0 <= fHPrime && fHPrime < 1) {
+        fR = fC;
+        fG = fX;
+        fB = 0;
+    } else if (1 <= fHPrime && fHPrime < 2) {
+        fR = fX;
+        fG = fC;
+        fB = 0;
+    } else if (2 <= fHPrime && fHPrime < 3) {
+        fR = 0;
+        fG = fC;
+        fB = fX;
+    } else if (3 <= fHPrime && fHPrime < 4) {
+        fR = 0;
+        fG = fX;
+        fB = fC;
+    } else if (4 <= fHPrime && fHPrime < 5) {
+        fR = fX;
+        fG = 0;
+        fB = fC;
+    } else if (5 <= fHPrime && fHPrime < 6) {
+        fR = fC;
+        fG = 0;
+        fB = fX;
+    } else {
+        fR = 0;
+        fG = 0;
+        fB = 0;
+    }
+
+    fR += fM;
+    fG += fM;
+    fB += fM;
+}
+
 class CellDrawable : public sf::Transformable, public sf::Drawable {
   public:
     CellDrawable(Maze &maze, Maze &virtualMaze, CellCoordinate pos)
@@ -48,16 +89,21 @@ class CellDrawable : public sf::Transformable, public sf::Drawable {
         state <<= 1;
         state |= maze.isExplored(pos);
 
+        float r, g, b, h, s = 1.0f, v = 1.0f;
+        HSVtoRGB(r, g, b,
+                 maze.getNode(pos).gScore / float(maze.getPath().cost) * 360,
+                 1.0f, 1.0f);
+
         sf::Color c;
         switch (state) {
             case EXPLORED:
-                c = sf::Color(150, 255, 255, 40);
+                c = sf::Color(150, 200, 200, 40);
                 break;
             case EVALUATED:
-                c = sf::Color(255, 255, 150, 40);
+                c = sf::Color(r * 255, g * 255, b * 255, 30);
                 break;
             case EXP_AND_EVAL:
-                c = sf::Color(255, 170, 170, 35);
+                c = sf::Color(r * 255, g * 255, b * 255, 70);
                 break;
             case DEFAULT:
             default:
@@ -189,7 +235,7 @@ class Simulator : public sf::RenderWindow {
                            sf::Style::Default, sf::ContextSettings(0, 0, 8))
         , mouse(mouse) {
         try {
-            mouse.virtualMaze = Maze::fromFile("2.maze");
+            mouse.virtualMaze = Maze::fromFile("1.maze");
         } catch (const std::exception &e) {
             std::cout << e.what();
         }

--- a/Simulation/simulate.cpp
+++ b/Simulation/simulate.cpp
@@ -15,6 +15,7 @@
 
 const std::string WINDOW_TITLE = "Micromouse simulator";
 const float NODE_SIZE = 1. / std::max<float>(Maze::NODE_COLS, Maze::NODE_ROWS);
+bool colorGradient = true;
 
 sf::Vector2f nodeVector(NodeCoordinate c) {
     return sf::Vector2f(.5 + c.x, Maze::NODE_ROWS - c.y - .5) * NODE_SIZE;
@@ -100,10 +101,12 @@ class CellDrawable : public sf::Transformable, public sf::Drawable {
                 c = sf::Color(150, 200, 200, 40);
                 break;
             case EVALUATED:
-                c = sf::Color(r * 255, g * 255, b * 255, 30);
+                colorGradient ? c = sf::Color(r * 255, g * 255, b * 255, 20)
+                              : c = sf::Color(255, 255, 150, 40);
                 break;
             case EXP_AND_EVAL:
-                c = sf::Color(r * 255, g * 255, b * 255, 70);
+                colorGradient ? c = sf::Color(r * 255, g * 255, b * 255, 70)
+                              : c = sf::Color(255, 170, 170, 35);
                 break;
             case DEFAULT:
             default:
@@ -276,6 +279,8 @@ class Simulator : public sf::RenderWindow {
             } else if (keyPress(sf::Keyboard::Down)) {
                 std::unique_lock<std::mutex> lock(mtx);
                 SIMULATION_SPEED /= 1.5f;
+            } else if (keyPress(sf::Keyboard::G)) {
+                colorGradient = !colorGradient;
             }
 
             sf::Event event;

--- a/Simulation/simulate.cpp
+++ b/Simulation/simulate.cpp
@@ -90,7 +90,7 @@ class CellDrawable : public sf::Transformable, public sf::Drawable {
         state <<= 1;
         state |= maze.isExplored(pos);
 
-        float r, g, b, h, s = 1.0f, v = 1.0f;
+        float r, g, b;
         HSVtoRGB(r, g, b,
                  maze.getNode(pos).gScore / float(maze.getPath().cost) * 360,
                  1.0f, 1.0f);

--- a/Simulation/simulate.cpp
+++ b/Simulation/simulate.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <cmath>
 
 const std::string WINDOW_TITLE = "Micromouse simulator";
 const float NODE_SIZE = 1. / std::max<float>(Maze::NODE_COLS, Maze::NODE_ROWS);


### PR DESCRIPTION
An old feature I was working on.
![image](https://cloud.githubusercontent.com/assets/4276762/25363597/8a40ba26-2910-11e7-98cb-bcbae1474c71.png)


Add hue gradient to the evaluated cells during pathfinding
toggle with `G` key

All cells with the same color have the same cost to travel to relative the origin of the pathfind.
(except where the red wraps back to red)


Looking at the "delta color" that occurs when a new wall is discovered may give some insight on better mapping strategies.