### PR TITLE
Add calibration routine for IRSensor

### DIFF
--- a/Micromouse/Hardware.cpp
+++ b/Micromouse/Hardware.cpp
@@ -47,13 +47,22 @@ void Hardware::setSpeed(unsigned mmps) {
 
 void Hardware::calibrateRangeFinders() {
     for (auto i : rangeFinders) {
-        i->calibrate();
+        if (i->calibrate()) {
+            i->saveCalibration();
+        } else {
+            Serial.printf("Error during calibration\n");
+            break;
+        }
     }
 }
 
 void Hardware::calibrateRangeFinder(Relation relation) {
     if (relation != NO_RELATION) {
-        rangeFinders[relation]->calibrate();
+        if (rangeFinders[relation]->calibrate()) {
+            rangeFinders[relation]->saveCalibration();
+        } else {
+            Serial.printf("Error during calibration\n");
+        }
     }
 }
 

--- a/Micromouse/IRSensor.cpp
+++ b/Micromouse/IRSensor.cpp
@@ -97,22 +97,18 @@ bool IRSensor::loadCalibration() {
 }
 
 unsigned IRSensor::readSensor(unsigned samples, unsigned delay) const {
-    if (samples <= 1) {
-        return analogRead(DATA_PIN);
-    } else {
-        unsigned val = 0;
+    unsigned val = 0;
 
-        for (size_t i = 0;; i++) {
-            val += analogRead(DATA_PIN);
+    for (size_t i = 0;; i++) {
+        val += analogRead(DATA_PIN);
 
-            if (i >= samples)
-                break;
+        if (i >= samples)
+            break;
 
-            ::delay(delay);
-        }
-
-        return val / samples;
+        ::delay(delay);
     }
+
+    return val / samples;
 }
 
 float IRSensor::calcDistance(unsigned sensorVal) const {

--- a/Micromouse/IRSensor.cpp
+++ b/Micromouse/IRSensor.cpp
@@ -1,6 +1,120 @@
 #include "IRSensor.h"
+#include <Arduino.h>
+#include <cmath>
 
-float IRSensor::getDistance() {
-    // TODO
-    return 0.0f;
+float IRSensor::getDistance() const {
+    // TODO: add smoothing and filtering.
+    return calcDistance(readSensor());
+}
+
+bool IRSensor::calibrate() {
+    Serial.printf("Distance %umm\n", MIN_RANGE);
+
+    // TODO: Wait for button press
+    delay(5000);
+
+    upperBound = readSensor(40);
+
+    Serial.printf("Distance %umm\n", MAX_RANGE);
+
+    // TODO: Wait for button press
+    delay(5000);
+
+    lowerBound = readSensor(40);
+
+    const auto samples = 3; // Only works with 3.
+
+    unsigned x[samples];
+    unsigned y[samples];
+
+    y[0] = MIN_RANGE + 20;
+    y[2] = MAX_RANGE - 30;
+    y[1] = (y[0] + y[2]) / 20 * 10;
+
+// Load fake values on PC.
+#if !defined(__MK66FX1M0__) && !defined(__MK20DX256__)
+    lowerBound = 373;
+    upperBound = 88;
+    x[0] = 248;
+    x[1] = 145;
+    x[2] = 105;
+#else
+    for (size_t s = 0; s < samples; s++) {
+        Serial.printf("Distance %umm\n", y[s]);
+
+        // TODO: Wait for button press
+        delay(5000);
+
+        x[s] = readSensor(40);
+
+        if (x[s] <= lowerBound || x[s] >= upperBound)
+            return false;
+    }
+#endif
+
+    a = 0.f;
+    c = 0.f;
+
+    // Iteratively improve the fit line.
+    for (size_t i = 0; i < 100; i++) {
+        b = (y[2] - c) * (x[2] + a);
+
+        c += y[0] - calcDistance(x[0]);
+
+        b = (y[2] - c) * (x[2] + a);
+
+        float m, q, ym;
+
+        m = (calcDistance(x[2]) - calcDistance(x[0])) / (y[2] - y[0]);
+        q = (y[2] * calcDistance(x[0]) - y[0] * calcDistance(x[2])) /
+            (y[2] - y[0]);
+        ym = m * y[1] + q;
+
+        a += a + (b + c * x[1] - ym * x[1]) / (c - ym);
+    }
+
+    float r = 0.0f;
+    // Calculate rough indicator of how good the calibration is.
+    for (size_t s = 0; s < samples; s++) {
+        r += pow(y[s] - calcDistance(x[s]), 2);
+    }
+    r += pow(MIN_RANGE - calcDistance(upperBound), 2);
+    r += pow(MAX_RANGE - calcDistance(lowerBound), 2);
+
+    Serial.printf("Calibration Results: \n a:%12.2f \n b:%12.2F \n c:%12.2F \n "
+                  "r:%12.4F \n",
+                  a, b, c, r);
+
+    return true;
+}
+
+bool IRSensor::loadCalibration() {
+    // TODO: load for real.
+    a = -14.2064f;
+    b = 11875.f;
+    c = -10.794f;
+    return true;
+}
+
+unsigned IRSensor::readSensor(unsigned samples, unsigned delay) const {
+    if (samples <= 1) {
+        return analogRead(DATA_PIN);
+    } else {
+        unsigned val = 0;
+
+        for (size_t i = 0;; i++) {
+            val += analogRead(DATA_PIN);
+
+            if (i >= samples)
+                break;
+
+            ::delay(delay);
+        }
+
+        return val / samples;
+    }
+}
+
+float IRSensor::calcDistance(unsigned sensorVal) const {
+    return b / (sensorVal + a) + c;
 }

--- a/Micromouse/IRSensor.h
+++ b/Micromouse/IRSensor.h
@@ -7,5 +7,14 @@ class IRSensor : public RangeFinder {
         : RangeFinder(pin, minRange, maxRange){};
     ~IRSensor() = default;
 
-    float getDistance();
+    float getDistance() const;
+    bool calibrate();
+    bool loadCalibration();
+
+  private:
+    unsigned readSensor(unsigned samples = 1, unsigned delay = 40) const;
+    float calcDistance(unsigned sensorVal) const;
+
+    float a, b, c;
+    unsigned lowerBound, upperBound;
 };

--- a/Micromouse/RangeFinder.h
+++ b/Micromouse/RangeFinder.h
@@ -9,13 +9,11 @@ class RangeFinder {
     // Max distance for sensor in mm.
     const unsigned MAX_RANGE;
 
-    // These may need to be virtual.
-    // Going to try to avoid it.
-    bool calibrate(/*TODO*/);
-    bool loadCalibration(/*TODO*/);
-    void saveCalibration(/*TODO*/);
+    virtual bool calibrate(/*TODO*/);
+    virtual bool loadCalibration(/*TODO*/);
+    virtual void saveCalibration(/*TODO*/);
 
-    virtual float getDistance() = 0;
+    virtual float getDistance() const = 0;
     virtual ~RangeFinder() = default;
 
   protected:

--- a/Micromouse/UltrasonicSensor.cpp
+++ b/Micromouse/UltrasonicSensor.cpp
@@ -1,6 +1,6 @@
 #include "UltrasonicSensor.h"
 
-float UltrasonicSensor::getDistance() {
+float UltrasonicSensor::getDistance() const {
     // TODO
     return 0.0f;
 }

--- a/Micromouse/UltrasonicSensor.h
+++ b/Micromouse/UltrasonicSensor.h
@@ -7,5 +7,5 @@ class UltrasonicSensor : public RangeFinder {
         : RangeFinder(pin, minRange, maxRange){};
     ~UltrasonicSensor() = default;
 
-    float getDistance();
+    float getDistance() const;
 };


### PR DESCRIPTION
Closes #73 

The calibration uses the general form y=b/(x+a)+c along with 3 points to calculate the coefficients.
A very good linear result is achieved.

Actual distance vs Calculated distance
![image](https://cloud.githubusercontent.com/assets/4276762/25561886/cf163276-2d29-11e7-93c2-0664d72e1823.png)
